### PR TITLE
fix(plugins/plugin-bash-like): singleton tables emitted by bash-like have table title

### DIFF
--- a/packages/app/web/css/kui-tables-common.css
+++ b/packages/app/web/css/kui-tables-common.css
@@ -93,7 +93,7 @@ body.sidecar-is-minimized .result-as-table .result-table {
   width: auto;
 }
 
-.result-table-outer-wrapper:not(:only-child) .result-table-title-outer {
+.result-table-outer-wrapper:not(:only-of-type) .result-table-title-outer {
   display: flex;
 }
 .result-table-title-outer {

--- a/plugins/plugin-bash-like/src/pty/client.ts
+++ b/plugins/plugin-bash-like/src/pty/client.ts
@@ -611,7 +611,7 @@ export const doExec = (
       // attach the terminal to the DOM
       try {
         const parent = block.querySelector('.repl-result')
-        const xtermContainer = document.createElement('div')
+        const xtermContainer = document.createElement('xterm')
         xtermContainer.classList.add('xterm-container')
         xtermContainer.classList.add('repl-output-like')
         // xtermContainer.classList.add('zoomable')


### PR DESCRIPTION
Fixes #2530

The screenshot below shows: 
1. (PR doesn't affect): singleton table **without** xterm-container sibling doesn't have table title
2. (**PR **fixes****): singleton table **with** xterm-container sibling shouldn't have table title
3. (PR doesn't affect): mutli-table has titles
![Screen Shot 2019-08-26 at 1 39 19 PM](https://user-images.githubusercontent.com/21212160/63710344-fc507100-c806-11e9-9867-a8929962d3fa.png)
![Screen Shot 2019-08-26 at 1 40 13 PM](https://user-images.githubusercontent.com/21212160/63710389-0f634100-c807-11e9-9397-971469510860.png)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.