### PR TITLE
fix(plugins/plugin-core-support): remove `version --update-check` command

### DIFF
--- a/plugins/plugin-core-support/src/lib/cmds/about/about.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/about/about.ts
@@ -305,45 +305,13 @@ const getVersion = () => {
 const reportVersion = ({ argv }: EvaluatorArgs) => {
   debug('reportVersion')
 
-  const checkForUpdates = argv.find(_ => _ === '-u' || _ === '--update-check')
   const version = getVersion()
 
-  if (!checkForUpdates) {
-    // we were asked only to report the installed version
-    if (extras['build-info']) {
-      return `${version} (build ${extras['build-info']})`
-    }
-    return version
+  // we were asked only to report the installed version
+  if (extras['build-info']) {
+    return `${version} (build ${extras['build-info']})`
   }
-
-  //
-  // otherwise, we were asked to check for updates
-  //
-  if (isHeadless()) {
-    console.log('You are currently on version ' + colors.blue(version))
-    process.stdout.write(colors.dim('Checking for updates... '))
-  }
-
-  return repl.qexec('updater check').then(updates => {
-    if (updates === true) {
-      // then we're up to date, so just report the version
-      if (isHeadless()) {
-        return 'you are up to date!'
-      } else {
-        return version
-      }
-    } else {
-      // then updates are available, so report the updates available message
-      if (isHeadless()) {
-        // above, we left with a process.stdout.write, so
-        // now we need to clear a newline see shell issue
-        // #194
-        console.log('')
-        console.log('')
-      }
-      return updates
-    }
-  })
+  return version
 }
 
 /**

--- a/plugins/plugin-core-support/src/lib/cmds/about/usage.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/about/usage.ts
@@ -23,13 +23,6 @@ export default {
     command: 'version',
     title: strings('versionUsageTitle'),
     header: strings('versionUsageHeader'),
-    example: 'version',
-    optional: [
-      {
-        name: '--update-check',
-        alias: '-u',
-        docs: strings('versionUsageOptionalDocs')
-      }
-    ]
+    example: 'version'
   }
 }


### PR DESCRIPTION
Note: This PR removes the command `version --update-check`, since we don't have real update checking. I keep the file `plugin-core-support/src/lib/admin/updater.ts` in our repo for future work.

Fixes #2529

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.