### PR TITLE
fix(plugins/plugin-k8s): kube tab completion of namespaces blank start

### DIFF
--- a/plugins/plugin-k8s/src/lib/tab-completion.ts
+++ b/plugins/plugin-k8s/src/lib/tab-completion.ts
@@ -52,8 +52,8 @@ async function completeResourceNames(commandLine: CommandLine, spec: TabCompleti
   const { argvNoOptions, argv, parsedOptions } = commandLine
 
   // index of the arg just before the one to be completed
-  const previous = spec.toBeCompletedIdx === -1 ? commandLine.argv.length : spec.toBeCompletedIdx - 1
-  if (previous >= 0 && (argv[previous] === '-n' || argv[previous] === '--namespace')) {
+  const previous = spec.toBeCompletedIdx === -1 ? commandLine.argv.length - 1 : spec.toBeCompletedIdx - 1
+  if (previous > 0 && (argv[previous] === '-n' || argv[previous] === '--namespace')) {
     //
     // then we are being asked to complete a namespace
     //


### PR DESCRIPTION
Fixes #2549

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
