### PR TITLE
fix(plugins-plugin-core-support): reverse-i-search glitches with bott…

### DIFF
--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -267,9 +267,14 @@ body:not(.subwindow) repl.sidecar-visible .repl-block,
 }
 .repl-prompt-righty {
   color: var(--color-brand-01);
+  min-height: 1.25em;
 }
 .repl-prompt-righty svg path {
   fill: var(--color-brand-01);
+}
+.repl-prompt-righty .repl-temporary {
+  display: flex;
+  align-items: center;
 }
 
 /* repl right-hand decorations */


### PR DESCRIPTION
…om input

Fixes #2560
Fixes #2559

Changes:

1) don't show command history index; normal reverse-i-search doesn't, and it's meaningless to be presented with some random looking number
2) in bottom input mode, the height of the input area would change when i-search was activated
3) ctrl-c doesn't clear reverse-i-search when in bottom input mode (it doesn't need to normally, because normal terminals don't)
4) in bottom input mode, reverse-i-search isn't cleared when user initiates a "pexec" (again, it doesn't need to normally, because the next prompt block will get focus)


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
