### PR TITLE
fix: reverse-i-search should use monospace

### DIFF
--- a/packages/app/web/css/not-electron.css
+++ b/packages/app/web/css/not-electron.css
@@ -10,9 +10,6 @@ body.not-electron .repl-prompt {
 body.not-electron .repl-context {
   display: none;
 }
-body.not-electron .repl-prompt-righty {
-  margin-top: -3px;
-}
 
 body.not-electron .kui--hide-in-webpack {
   /* e.g. don't show screenshot buttons in webpack clients */

--- a/packages/app/web/css/ui.css
+++ b/packages/app/web/css/ui.css
@@ -391,14 +391,18 @@ body/*:not(.sidecar-full-screen)*/ repl.sidecar-visible .repl-selection, body/*.
 }
 .repl-input input,
 .repl-input-like {
+  --color-caret: var(--color-support-01);
   color: var(--color-text-01);
   background: transparent;
   border: none;
   flex: 1;
-  caret-color: var(--color-support-01);
+  caret-color: var(--color-caret);
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+.kui--prompt-like:empty {
+  border-right: 1ex solid var(--color-caret);
 }
 .repl-input input:focus,
 .repl-input-like:focus {
@@ -3234,6 +3238,9 @@ body.kui--bottom-input tab > .kui--rows > .kui--columns {
   flex: 1;
   background-color: var(--color-sidecar-header);
   padding: 0.5em 0.375em;
+}
+.kui--input-stripe .repl-input-like {
+  overflow: unset;
 }
 .kui--input-stripe input {
   background-color: transparent;

--- a/plugins/plugin-core-support/src/lib/cmds/history/reverse-i-search.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/history/reverse-i-search.ts
@@ -81,6 +81,7 @@ class ActiveISearch {
     this.placeholder.appendChild(this.placeholderFixedPart)
     this.placeholder.classList.add('repl-temporary')
     this.placeholder.classList.add('normal-text')
+    this.placeholder.classList.add('monospace')
     this.placeholderFixedPart.classList.add('smaller-text')
     this.placeholderFixedPart.classList.add('small-right-pad')
     this.promptLeft.appendChild(this.placeholder)
@@ -91,7 +92,7 @@ class ActiveISearch {
     //    this.prompt.style.width = '0'
 
     this.placeholderContentPart = document.createElement('span') // container for Typed and Matched
-    this.placeholderTypedPart = document.createElement('span') // what the user has typed; e.g. "is" in "history"
+    this.placeholderTypedPart = document.createElement('strong') // what the user has typed; e.g. "is" in "history"
     this.placeholderMatchedPrefixPart = document.createElement('span') // what was matched, but not typed; e.g. "h" in "history"
     this.placeholderMatchedSuffixPart = document.createElement('span') // what was matched, but not typed; e.g. "tory" in "history"
     this.placeholderContentPart.appendChild(this.placeholderMatchedPrefixPart)
@@ -101,6 +102,7 @@ class ActiveISearch {
     this.placeholder.appendChild(this.placeholderContentPart)
 
     this.placeholderTypedPart.classList.add('red-text')
+    this.placeholderTypedPart.classList.add('kui--prompt-like')
     this.placeholderMatchedPrefixPart.classList.add('slightly-deemphasize')
     this.placeholderMatchedSuffixPart.classList.add('slightly-deemphasize')
 


### PR DESCRIPTION
this also fixes a few other minor anomalies with the reverse-i-search UI:

1) webpack clients have an anomalous -3px margin-top
2) no caret before the user types anything

Fixes #2580 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
