### PR TITLE
fix(plugins/plugin-editor): editor font size does not respect current…

### DIFF
--- a/plugins/plugin-editor/src/lib/init/amd.ts
+++ b/plugins/plugin-editor/src/lib/init/amd.ts
@@ -109,15 +109,10 @@ export default (editorWrapper: HTMLElement, options) => {
               initDone = true
             }
 
-            // see if we are in dark mode
-            const theme = {
-              theme: document.querySelector('body').getAttribute('kui-theme-style') === 'dark' ? 'vs-dark' : 'vs'
-            }
-
             // here we instantiate an editor widget
             editor = global['monaco'].editor.create(
               editorWrapper,
-              Object.assign(defaultMonacoOptions(options), theme, options)
+              Object.assign(defaultMonacoOptions(options), options)
             )
 
             resolve(editor)

--- a/plugins/plugin-editor/src/lib/init/defaults.ts
+++ b/plugins/plugin-editor/src/lib/init/defaults.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-export default options => ({
+interface Options {
+  readOnly?: boolean
+  simple?: boolean
+}
+
+export default (options: Options) => ({
   automaticLayout: false, // respond to window layout changes?
   minimap: {
     enabled: false
@@ -30,7 +35,7 @@ export default options => ({
   fontFamily: 'var(--font-monospace)',
   fontSize:
     parseInt(
-      getComputedStyle(document.body)
+      getComputedStyle(document.querySelector('.repl-inner'))
         .getPropertyValue('font-size')
         .replace(/px$/, ''),
       10

--- a/plugins/plugin-editor/src/lib/init/esm.ts
+++ b/plugins/plugin-editor/src/lib/init/esm.ts
@@ -91,13 +91,8 @@ export default (editorWrapper: HTMLElement, options) => {
           initDone = true
         }
 
-        // see if we are in dark mode
-        const theme = {
-          theme: document.querySelector('body').getAttribute('kui-theme-style') === 'dark' ? 'vs-dark' : 'vs'
-        }
-
         // here we instantiate an editor widget
-        editor = monaco.editor.create(editorWrapper, Object.assign(defaultMonacoOptions(options), theme, options))
+        editor = monaco.editor.create(editorWrapper, Object.assign(defaultMonacoOptions(options), options))
 
         editor.clearDecorations = () => {
           debug('clearing decorations', editor.__cloudshell_decorations)

--- a/plugins/plugin-editor/src/lib/open.ts
+++ b/plugins/plugin-editor/src/lib/open.ts
@@ -87,20 +87,15 @@ let pre2 = false
 /**
  * Inject the current theme into the editor
  *
- * @param editorWrapper null allows for pre-injecting of CSS (performance optimization)
  */
-const injectTheme = (editorWrapper?: Element, force = false) => {
-  if (pre && !force) {
-    debug('skipping injectTheme', pre, force)
+const injectTheme = () => {
+  if (pre) {
+    debug('skipping injectTheme', pre)
     return
   }
   debug('injectTheme')
 
-  const currentTheme = document.querySelector('body').getAttribute('kui-theme')
-
-  const previousKey = editorWrapper && editorWrapper.getAttribute('kui-theme-key')
-  const key = `editor.theme-${currentTheme}`
-  if (editorWrapper) editorWrapper.setAttribute('kui-theme-key', key)
+  const key = `kui.editor.theme`
 
   // dangit: in webpack we can require the CSS; but in plain nodejs,
   // we cannot, so have to use filesystem operations to acquire the
@@ -115,13 +110,6 @@ const injectTheme = (editorWrapper?: Element, force = false) => {
     // oh well, try filesystem style
     const ourRoot = path.dirname(require.resolve('@kui-shell/plugin-editor/package.json'))
     injectCSS({ key, path: path.join(ourRoot, 'web/css/theme-alignment.css') })
-  }
-
-  // remove previous theme; for some reason, if we don't do this as an
-  // async, chrome flashes as we change themes!
-  if (editorWrapper) {
-    setTimeout(() => uninjectCSS({ key: previousKey }), 0)
-    pre = false
   }
 }
 
@@ -200,8 +188,8 @@ export const openEditor = async (tab: Tab, name: string, options, execOptions) =
     evt.stopPropagation()
   }
 
-  injectTheme(editorWrapper) // inject right now
-  globalEventBus.on('/theme/change', () => injectTheme(editorWrapper, true)) // and re-inject when the theme changes
+  // inject the kui-to-monaco theme alignment css
+  injectTheme()
 
   /**
    * Given an editor instance, return a function that can update


### PR DESCRIPTION
… font size

this also cleans up some old unused cruft with theme handling. the current scheme is much simpler, with a single theme-alignment.css; the original code was intended to have one .css per theme. since that is no longer the case, we can remove a bit of code

Fixes #1565

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
