### PR TITLE
fix(plugins/plugin-k8s): `k get resource -w` doesn't error out for `resource not found`

### DIFF
--- a/plugins/plugin-k8s/src/lib/controller/kubectl.ts
+++ b/plugins/plugin-k8s/src/lib/controller/kubectl.ts
@@ -499,8 +499,10 @@ const executeLocally = (command: string) => (opts: EvaluatorArgs) =>
         }
 
         if (codeForREPL === 404 || codeForREPL === 409 || codeForREPL === 412) {
-          if (codeForREPL === 404 && verb === 'get' && (options.w || options.watch)) {
-            // NOTE(5.30.2019): for now, we only support watchable table, so we have to return an empty table here
+          if (codeForREPL === 404 && originalCode === 0 && verb === 'get' && (options.w || options.watch)) {
+            // NOTE: although the error message is 'resource not found',
+            // kubectl doesn't treat this as an error when the command is a watch command,
+            // so we return an empty result and watch for changes
             debug('return an empty watch table')
             return cleanupAndResolve(
               formatWatchableTable(new Table({ body: [] }), {

--- a/plugins/plugin-k8s/src/test/k8s2/watch-error-handling.ts
+++ b/plugins/plugin-k8s/src/test/k8s2/watch-error-handling.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as common from '@kui-shell/core/tests/lib/common'
+import { cli } from '@kui-shell/core/tests/lib/ui'
+import { createNS, allocateNS, deleteNS } from '@kui-shell/plugin-k8s/tests/lib/k8s/utils'
+
+describe(`kubectl watch error handler ${process.env.MOCHA_RUN_TARGET}`, function(this: common.ISuite) {
+  before(common.before(this))
+  after(common.after(this))
+
+  const testResourceNotFound = (watchCmd: string, resourceType: string, resourceName: string) => {
+    const errorMessage = `Error from server (NotFound): ${resourceType} "${resourceName}" not found`
+
+    it(`should error out when watching a non-existent ${resourceType}`, () => {
+      return cli
+        .do(watchCmd, this.app)
+        .then(cli.expectError(404, errorMessage))
+        .catch(common.oops(this))
+    })
+  }
+
+  const testWrongCommand = (watchCmd: string, resourceName: string) => {
+    const errorMessage = `error: the server doesn't have a resource type "${resourceName}"`
+
+    it(`should error out with wrong command ${watchCmd}`, () => {
+      return cli
+        .do(watchCmd, this.app)
+        .then(cli.expectError(404, errorMessage))
+        .catch(common.oops(this))
+    })
+  }
+
+  // here comes the tests that expect failure due to not existant resources
+  const flags = ['-w', '--watch=true']
+  flags.forEach(watch => {
+    testResourceNotFound(`k get ns shouldNotExist ${watch}`, 'namespaces', 'shouldNotExist')
+    testResourceNotFound(`k get ns ${watch} shouldNotExist`, 'namespaces', 'shouldNotExist')
+
+    testResourceNotFound(`k get pod shouldNotExist ${watch}`, 'pods', 'shouldNotExist')
+    testResourceNotFound(`k get ${watch} pod shouldNotExist`, 'pods', 'shouldNotExist')
+
+    testResourceNotFound(`k get pods shouldNotExist -n shouldNotExist ${watch}`, 'namespaces', 'shouldNotExist')
+  })
+
+  // here comes the tests that expect failure due to wrong flag
+  const wrongFlags = ['--watch true', '-w true']
+  wrongFlags.forEach(watch => {
+    testResourceNotFound(`k get pod ${watch}`, 'pods', 'true') // the command is parsed as `kubectl get pod true`
+    testWrongCommand(`k get ${watch} pod`, 'true') // the command is parsed as `kubectl get true pod`
+  })
+
+  // here comes the tests should be successful
+  const ns = createNS()
+  it('should watch pods in non-existent namespace but see empty table', () => {
+    return cli
+      .do(`k get pods -n ${ns} -w`, this.app)
+      .then(cli.expectOK)
+      .catch(common.oops(this))
+  })
+
+  allocateNS(this, ns)
+  deleteNS(this, ns)
+})


### PR DESCRIPTION
Fixes #2731

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
