### PR TITLE
feat: initial typeahead for commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kui-shell",
-  "version": "8.11.0",
+  "version": "8.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -74,9 +74,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-      "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.4.tgz",
+      "integrity": "sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.11.0",
@@ -212,9 +212,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.11.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
-      "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.4.tgz",
+      "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
       "dev": true
     },
     "@babel/plugin-syntax-dynamic-import": {
@@ -357,6 +357,7 @@
         "properties-parser": "0.3.1",
         "readline": "^1.3.0",
         "tmp": "0.2.1",
+        "trie-search": "1.2.11",
         "uuid": "8.2.0",
         "yargs-parser": "18.1.3"
       }
@@ -2562,9 +2563,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001116",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001116.tgz",
-      "integrity": "sha512-f2lcYnmAI5Mst9+g0nkMIznFGsArRmZ0qU+dnq8l91hymdc2J3SFbiPhOJEeDqC1vtE8nc1qNQyklzB8veJefQ==",
+      "version": "1.0.30001117",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz",
+      "integrity": "sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==",
       "dev": true
     },
     "carbon-components": {
@@ -4376,9 +4377,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.539",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.539.tgz",
-      "integrity": "sha512-rM0LWDIstdqfaRUADZetNrL6+zd/0NBmavbMEhBXgc2u/CC1d1GaDyN5hho29fFvBiOVFwrSWZkzmNcZnCEDog==",
+      "version": "1.3.540",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.540.tgz",
+      "integrity": "sha512-IoGiZb8SMqTtkDYJtP8EtCdvv3VMtd1QoTlypO2RUBxRq/Wk0rU5IzhzhMckPaC9XxDqUvWsL0XKOBhTiYVN3w==",
       "dev": true
     },
     "elegant-spinner": {
@@ -6440,6 +6441,14 @@
         "is-stream": "^1.0.1"
       }
     },
+    "hasharray": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hasharray/-/hasharray-1.1.1.tgz",
+      "integrity": "sha512-L+WTUz5XcfQyh3652tOEDLL5ZG6MAS+iYqM2K0N9H/z7RpW0rjlFkXLRdqbwqrGCr9korJzyfDD7i7mtwo42wg==",
+      "requires": {
+        "jclass": "^1.0.1"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -7610,6 +7619,11 @@
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
       }
+    },
+    "jclass": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/jclass/-/jclass-1.2.1.tgz",
+      "integrity": "sha1-6q/uwN1qW/iz6kPATgEMY3Y4dos="
     },
     "jquery": {
       "version": "3.5.0",
@@ -9225,9 +9239,9 @@
       }
     },
     "node-abi": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
-      "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.0.tgz",
+      "integrity": "sha512-rpKqVe24p9GvMTgtqUXdLR1WQJBGVlkYPU10qHKv9/1i9V/k04MmFLVK2WcHBf1WKKY+ZsdvARPi8F4tfJ4opA==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -13922,6 +13936,14 @@
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
+    },
+    "trie-search": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/trie-search/-/trie-search-1.2.11.tgz",
+      "integrity": "sha512-iENSdED6uNFRkJg4c/WOpBDlM/Qk5ovihK98cCEhH8vh5eorldycLgPxgaeO+JBBslbq6pHMDSdP2fuLv9VZzA==",
+      "requires": {
+        "hasharray": "^1.1.1"
+      }
     },
     "trim": {
       "version": "0.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "properties-parser": "0.3.1",
     "readline": "^1.3.0",
     "tmp": "0.2.1",
+    "trie-search": "1.2.11",
     "uuid": "8.2.0",
     "yargs-parser": "18.1.3"
   },

--- a/packages/core/src/@types/trie-search.d.ts
+++ b/packages/core/src/@types/trie-search.d.ts
@@ -1,0 +1,24 @@
+declare module 'trie-search' {
+  interface ConverterOptions {
+    /** The default foreground color used when reset color codes are encountered. */
+    fg?: string
+    /** The default background color used when reset color codes are encountered. */
+    bg?: string
+    /** Convert newline characters to `<br/>`. */
+    newline?: boolean
+    /** Generate HTML/XML entities. */
+    escapeXML?: boolean
+    /** Save style state across invocations of `toHtml()`. */
+    stream?: boolean
+    /** Can override specific colors or the entire ANSI palette. */
+    colors?: string[] | {[code: number]: string}
+  }
+
+  class TrieSearch<V extends any> {
+    constructor(name?: string)
+    map(key: string, value: V): void
+    get(key: string): V[]
+  }
+
+  export default TrieSearch
+}

--- a/packages/core/src/commands/typeahead.ts
+++ b/packages/core/src/commands/typeahead.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import TrieSearch from 'trie-search'
+
+import { getCurrentContext } from '../commands/context'
+
+const trie = new TrieSearch<string>() // Command<KResponse, ParsedOptions>>()
+const trieWithoutContext = new TrieSearch<string>() // Command<KResponse, ParsedOptions>>()
+
+/**
+ * Enter newly registered command in the trie
+ *
+ */
+export function registerTypeahead(route: string) {
+  trie.map(route, route)
+
+  const routeWithoutImplicitContext = route.replace(new RegExp(`^/${getCurrentContext()}`), '')
+  trieWithoutContext.map(routeWithoutImplicitContext, routeWithoutImplicitContext)
+}
+
+/**
+ * User expressed `base`, and it matches the full `route`. Return the
+ * relevant suffix of `route`, expressed with whitespace.
+ *
+ */
+function typeaheadMatch(base: string[], route: string | void): string | void {
+  if (route) {
+    const that = route.split(/\//)
+    const N = Math.min(base.length, that.length)
+
+    let idx = 0
+    for (; idx < N; idx++) {
+      if (base[idx] !== that[idx]) {
+        break
+      }
+    }
+
+    if (idx < N) {
+      // kubectl g -> et (no extra)
+      // kubectl f -> oo bar (hypothetical, but imagine there were a unique multi-word match)
+      const extra = that.slice(idx + 1).join(' ')
+      return that[idx].slice(base[idx].length) + (extra ? ` ${extra}` : '')
+    } else {
+      // add only the "extra"
+      return that.slice(idx).join(' ')
+    }
+  }
+}
+
+function findMinimalCommonPrefix(matches: string[]): string | void {
+  if (matches.length > 0) {
+    const N = matches.reduce((N, match) => (N === -1 ? match.length : Math.min(N, match.length)), -1)
+    for (let idx = 0; idx < N; idx++) {
+      const k = matches[0][idx]
+      for (let jdx = 1; jdx < matches.length; jdx++) {
+        if (matches[jdx][idx] !== k) {
+          return matches[0].slice(0, idx)
+        }
+      }
+    }
+
+    return matches[0]
+  }
+}
+
+/**
+ * Typeahead find lookup
+ *
+ * @return list of matches
+ *
+ */
+export default function typeahead(prefix: string): string[] {
+  if (prefix.length === 0) {
+    return []
+  } else {
+    const desired = `/${prefix
+      .replace(/^\s+/, '')
+      .split(/\s+/)
+      .join('/')}`
+
+    // look up first without context, then with implicit context
+    const try1 = trieWithoutContext.get(desired)
+    const results = try1.length === 0 ? trie.get(desired) : try1
+
+    const maybe = typeaheadMatch(desired.split(/\//), findMinimalCommonPrefix(results /* .map(_ => _.route) */))
+    if (maybe) {
+      return [maybe]
+    } else {
+      return []
+    }
+  }
+}

--- a/packages/core/src/core/command-tree.ts
+++ b/packages/core/src/core/command-tree.ts
@@ -48,7 +48,6 @@ import { PluginResolver } from '../plugins/resolver'
 
 import { getModelInternal } from '../commands/tree'
 import { Context, getCurrentContext } from '../commands/context'
-
 debug('finished loading modules')
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export {
 export { CapabilityRegistration } from './models/plugin'
 
 // Commands
+export { default as typeahead } from './commands/typeahead'
 export { default as AlwaysViewIn } from './models/AlwaysViewIn'
 export {
   CommandHandler,

--- a/packages/core/src/plugins/plugins.ts
+++ b/packages/core/src/plugins/plugins.ts
@@ -26,6 +26,7 @@ import { KuiPlugin } from '../models/plugin'
 import { userDataDir } from '../core/userdata'
 import { isHeadless } from '../core/capabilities'
 import { setPluginResolver } from '../core/command-tree'
+import { registerTypeahead } from '../commands/typeahead'
 
 debug('modules loaded')
 
@@ -47,6 +48,11 @@ let basePrescan: PrescanModel // without any user-installed plugins
 let prescan: PrescanModel
 try {
   prescan = require('@kui-shell/prescan.json') as PrescanModel // the result of unify(basePrescan, userPrescan)
+
+  // populate the typeahead trie
+  if (prescan && prescan.commandToPlugin) {
+    Object.keys(prescan.commandToPlugin).forEach(registerTypeahead)
+  }
 } catch (err) {
   debug(err)
 }

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/Input.tsx
@@ -121,6 +121,9 @@ export interface State {
   /** spinner? */
   spinner?: ReturnType<typeof setInterval>
   spinnerDom?: HTMLSpanElement
+
+  /** typeahead completion? */
+  typeahead?: string
 }
 
 export abstract class InputProvider<S extends State = State> extends React.PureComponent<Props, S> {
@@ -333,29 +336,32 @@ export default class Input extends InputProvider {
       }
 
       return (
-        <input
-          type="text"
-          autoFocus
-          autoCorrect="off"
-          autoComplete="off"
-          spellCheck="false"
-          autoCapitalize="off"
-          className={'repl-input-element' + (this.state.isearch ? ' repl-input-hidden' : '')}
-          aria-label="Command Input"
-          tabIndex={1}
-          placeholder={this.props.promptPlaceholder}
-          onBlur={this.props.onInputBlur}
-          onFocus={this.props.onInputFocus}
-          onMouseDown={this.props.onInputMouseDown}
-          onMouseMove={this.props.onInputMouseMove}
-          onChange={this.props.onInputChange}
-          onClick={this.props.onInputClick}
-          onKeyPress={this._onKeyPress}
-          onKeyDown={this._onKeyDown}
-          onKeyUp={this._onKeyUp}
-          onPaste={this._onPaste}
-          ref={this._onRef}
-        />
+        <React.Fragment>
+          <input
+            type="text"
+            autoFocus
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck="false"
+            autoCapitalize="off"
+            className={'repl-input-element' + (this.state.isearch ? ' repl-input-hidden' : '')}
+            aria-label="Command Input"
+            tabIndex={1}
+            placeholder={this.props.promptPlaceholder}
+            onBlur={this.props.onInputBlur}
+            onFocus={this.props.onInputFocus}
+            onMouseDown={this.props.onInputMouseDown}
+            onMouseMove={this.props.onInputMouseMove}
+            onChange={this.props.onInputChange}
+            onClick={this.props.onInputClick}
+            onKeyPress={this._onKeyPress}
+            onKeyDown={this._onKeyDown}
+            onKeyUp={this._onKeyUp}
+            onPaste={this._onPaste}
+            ref={this._onRef}
+          />
+          {this.state.typeahead && <span className="kui--input-typeahead">{this.state.typeahead}</span>}
+        </React.Fragment>
       )
     } else {
       const value =

--- a/plugins/plugin-kubectl/src/test/k8s1/tab-completion.ts
+++ b/plugins/plugin-kubectl/src/test/k8s1/tab-completion.ts
@@ -35,6 +35,10 @@ describe(`kubectl get tab completion ${process.env.MOCHA_RUN_TARGET || ''}`, fun
     const ns2 = `${commonPrefix}-bbbb` // we want ns to be lexicographically < ns2
     const ns3 = `${uniquePrefix}-cccc` // something prefix-distinct from the first two
 
+    it(`should tab complete kubectl command`, () => {
+      return tabby(this, 'kubect', 'kubectl')
+    })
+
     allocateNS(this, ns)
     allocateNS(this, ns2)
     allocateNS(this, ns3)


### PR DESCRIPTION
Implemtation:
 - leverages tab completion UI
 - populates trie when loading the prescan model

Limitations:
 - only completes shared common prefixes, no multi-completions yet
 - only works to the level of detail of registrar.listen(); if command handlers do internal dispatching, this will not surface to tab completion

This does not leverage the trie model fully. In the future, we could offer a help sidecar that lets the user search for commands. There, we could leverage the trie to offer true typeahead find.

Fixes #5437

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
