### PR TITLE
feat(plugins/plugin-client-common): allow Clients not to show StatusStripe

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -320,9 +320,15 @@ export class Kui extends React.PureComponent<Props, State> {
                 onTabReady={this.state.commandLine && this._onTabReady}
               ></TabContainer>
               {this.props.toplevel}
-              <StatusStripe noHelp={this.props.noHelp} noSettings={this.props.noSettings} {...this.statusStripeProps()}>
-                {this.props.children}
-              </StatusStripe>
+              {this.props.statusStripe !== false && (
+                <StatusStripe
+                  noHelp={this.props.noHelp}
+                  noSettings={this.props.noSettings}
+                  {...this.statusStripeProps()}
+                >
+                  {this.props.children}
+                </StatusStripe>
+              )}
             </div>
           </React.Suspense>
         </KuiContext.Provider>

--- a/plugins/plugin-client-common/src/components/Client/props/FeatureFlags.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/FeatureFlags.ts
@@ -24,6 +24,9 @@ type FeatureFlags = {
   /** [Optional] Enable Split Terminals? */
   splitTerminals?: boolean
 
+  /** [Optional] Show bottom status stripe? [default: true] */
+  statusStripe?: boolean
+
   /** Operate in popup mode? */
   isPopup?: boolean
 


### PR DESCRIPTION
This PR introduces a `statusStripe` property to`<Kui/>`, e.g.

```jsx
<Kui statusStripe={false} />
```

The default value is true, i.e. by default Kui clients will show the bottom StatusStripe.

Fixes #7359

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
