### PR TITLE
fix(plugins/plugin-client-common): in bottom strip, show split header…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/BottomStrip.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/BottomStrip.scss
@@ -142,6 +142,12 @@ $bgcolor: var(--color-base01);
         grid-area: B1;
         min-height: 6rem;
 
+        @include NotFocusedSplitAttributes {
+          @include SplitHeader {
+            display: none;
+          }
+        }
+
         @include FinishedBlock {
           flex: 1;
 
@@ -181,10 +187,6 @@ $bgcolor: var(--color-base01);
         }
         @include Grid {
           grid-template-columns: repeat(auto-fill, minmax(1.25em, auto)) !important;
-        }
-
-        @include SplitHeader {
-          display: none;
         }
 
         @include ScrollbackBlockList {

--- a/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/_mixins.scss
@@ -78,9 +78,15 @@ $action-hover-delay: 210ms;
   }
 }
 
+@mixin NotFocusedSplitAttributes {
+  &:not([data-is-focused]) {
+    @content;
+  }
+}
+
 @mixin NotFocusedSplit {
   @include Scrollback {
-    &:not([data-is-focused]):not([data-is-minisplit]) {
+    @include NotFocusedSplitAttributes {
       @content;
     }
   }


### PR DESCRIPTION
… when the split is focused

Previously, we would *never* show the splt header in bottom strip splits

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
