### PR TITLE
fix(plugins/plugin-client-common): BottomStrip splits min height 6rem…

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Terminal/Layout/BottomStrip.scss
+++ b/plugins/plugin-client-common/web/scss/components/Terminal/Layout/BottomStrip.scss
@@ -18,7 +18,11 @@
 @import '../../Table/mixins';
 @import '../../TopLevelTab/mixins';
 
+/** Special background color for BottomStrip splits */
 $bgcolor: var(--color-base01);
+
+/** Minimum height of a BottomStrip splits */
+$min-height: 7rem;
 
 @include NotebookTab {
   @include HasBottomStrip {
@@ -140,7 +144,7 @@ $bgcolor: var(--color-base01);
     @include Scrollback {
       @include BottomStrip {
         grid-area: B1;
-        min-height: 6rem;
+        min-height: $min-height;
 
         @include IsNotFocusedSplit {
           @include SplitHeader {


### PR DESCRIPTION
… -> 7rem

This allows space for the "Sample Output" expando in notebook mode

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
