### PR TITLE
fix: Added OS menu option to toggle edit mode

### DIFF
--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -85,6 +85,11 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
       },
       { type: 'separator' },
       {
+        label: 'Toggle Edit Mode',
+        click: () => tellRendererToExecute('tab edit toggle --current-tab')
+        // TODO find exactly what keyboard shortcut => accelerator: 'CommandOrControl+E'
+      },
+      {
         label: 'Save as Notebook...',
         click: saveAsNotebook,
         accelerator: 'CommandOrControl+S'

--- a/plugins/plugin-core-support/src/lib/cmds/toggle-editability.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/toggle-editability.ts
@@ -21,34 +21,60 @@ import {
   KResponse,
   ParsedOptions,
   Registrar,
-  StatusStripeChangeEvent
+  StatusStripeChangeEvent,
+  Tab
 } from '@kui-shell/core'
 
 interface EditOptions extends ParsedOptions {
   'new-window': boolean
   'status-stripe': StatusStripeChangeEvent['type']
+  current?: boolean
+  c?: boolean
+}
+
+/**
+ * The command usage model
+ *
+ */
+const usage = {
+  command: 'tab edit toggle',
+  strict: 'tab edit toggle',
+  optional: [{ name: '--current-tab', alias: '-c', boolean: true, docs: 'Toggle edit mode on current tab' }]
+}
+
+function getTabByIndex(argvNoOptions: string[]): Tab {
+  const index = parseInt(argvNoOptions[argvNoOptions.length - 1], 10)
+
+  if (isNaN(index)) {
+    throw new Error(`4th argument is not a number. Expected type number`)
+  } else {
+    const tmpTab = getTab(index)
+    if (tmpTab === undefined || tmpTab === null) {
+      throw new Error('Could not find tab with give index ' + index)
+    }
+    return tmpTab
+  }
 }
 
 /** Command registration */
 export default function(registrar: Registrar) {
   // register the `tab edit toggle` command
-  registrar.listen<KResponse, EditOptions>('/tab/edit/toggle', ({ argvNoOptions }) => {
-    if (argvNoOptions.length < 4) {
-      throw new Error('Not enough arguments. Expected: tab edit toggle tabIndexNum')
-    }
-
-    const index = parseInt(argvNoOptions[argvNoOptions.length - 1], 10)
-
-    if (isNaN(index)) {
-      throw new Error(`4th argument is not a number. Expected type number`)
-    } else {
-      const tab = getTab(index)
-      if (tab === undefined || tab === null) {
-        throw new Error('Could not find tab with give index ' + index)
+  registrar.listen<KResponse, EditOptions>(
+    '/tab/edit/toggle',
+    ({ tab, argvNoOptions, parsedOptions }) => {
+      if (!parsedOptions.c && argvNoOptions.length < 4) {
+        throw new Error('Not enough arguments. Expected: tab edit toggle tabIndexNum')
       }
-      const uuid = getPrimaryTabId(tab)
-      eventBus.emitWithTabId('/kui/tab/edit/toggle', uuid, tab)
+      if (argvNoOptions.length > 4) {
+        throw new Error('Too many arguments. Expected: tab edit toggle tabIndexNum')
+      }
+
+      const desiredTab = parsedOptions.c ? tab : getTabByIndex(argvNoOptions)
+
+      const uuid = getPrimaryTabId(desiredTab)
+      eventBus.emitWithTabId('/kui/tab/edit/toggle', uuid, desiredTab)
       return 'Successfully toggled edit mode'
-    }
-  })
+    },
+    { usage, flags: { alias: { 'current-tab': ['c'] }, boolean: ['c'] } }
+  )
 }


### PR DESCRIPTION
Fixes #8061

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<img width="1533" alt="UI-toggle-edit-mode" src="https://user-images.githubusercontent.com/16118462/136821861-073dfb50-aab0-4cdf-bb1f-afd3b17131da.png">

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
