### PR TITLE
fix: notebooks do not open scrolled to top

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -88,6 +88,7 @@ class WriteEventBus extends EventBusBase {
   public emit(channel: '/tab/new/request', evt?: NewTabRequestEvent): void
   public emit(channel: '/tab/switch/request', idx: number): void
   public emit(channel: '/tab/switch/request/done', args: { idx: number; tab: TabState }): void
+  public emit(channel: '/kui/tab/edit/toggle/index', idx: number): void
   public emit(channel: string, args?: any) {
     return this.eventBus.emit(channel, args)
   }
@@ -178,10 +179,16 @@ class ReadEventBus extends WriteEventBus {
   public on(channel: '/tab/new/request', listener: (evt: NewTabRequestEvent) => void): void
   public on(channel: '/tab/switch/request', listener: (tabId: number) => void): void
   public on(channel: '/tab/switch/request/done', listener: (tabId: number, tabState: TabState) => void): void
+  public on(channel: '/kui/tab/edit/toggle/index', listener: (idx: number) => void): void
   public on(channel: string, listener: any) {
     return this.eventBus.on(channel, listener)
   }
 
+  public off(channel: '/tab/new', listener: (tab: Tab) => void): void
+  public off(channel: '/tab/new/request', listener: (evt: NewTabRequestEvent) => void): void
+  public off(channel: '/tab/switch/request', listener: (tabId: number) => void): void
+  public off(channel: '/tab/switch/request/done', listener: (tabId: number, tabState: TabState) => void): void
+  public off(channel: '/kui/tab/edit/toggle/index', listener: (idx: number) => void): void
   public off(channel: string, listener: any) {
     return this.eventBus.off(channel, listener)
   }

--- a/packages/test/src/api/cli.ts
+++ b/packages/test/src/api/cli.ts
@@ -220,12 +220,14 @@ export async function nOfCurrentBlock(app: Application, splitIndex = 1) {
 }
 
 /** Index of last executed block */
-export async function lastBlock(app: Application, splitIndex = 1): Promise<AppAndCount> {
+export async function lastBlock(app: Application, splitIndex = 1, N = 1, inNotebook = false): Promise<AppAndCount> {
   return {
     app,
     splitIndex: splitIndex,
     count: parseInt(
-      await app.client.$(Selectors.PROMPT_BLOCK_LAST_FOR_SPLIT(splitIndex)).then(_ => _.getAttribute(Selectors.N_ATTR)),
+      await app.client
+        .$(Selectors.PROMPT_BLOCK_LAST_FOR_SPLIT(splitIndex, N, inNotebook))
+        .then(_ => _.getAttribute(Selectors.N_ATTR)),
       10
     )
   }
@@ -239,8 +241,8 @@ export async function expandNth(app: Application, N: number, splitIndex = 1) {
 }
 
 /** Click to expand the last replayed sample output */
-export async function expandLast(app: Application, splitIndex = 1) {
-  const expando = await app.client.$(Selectors.EXPANDABLE_OUTPUT_LAST(splitIndex))
+export async function expandLast(app: Application, splitIndex = 1, N = 1) {
+  const expando = await app.client.$(Selectors.EXPANDABLE_OUTPUT_LAST_IN_NOTEBOOK(splitIndex, N))
   await expando.waitForExist()
   await expando.click()
 }

--- a/packages/test/src/api/selectors.ts
+++ b/packages/test/src/api/selectors.ts
@@ -173,8 +173,31 @@ export const PROMPT_BLOCK_N_FOR_SPLIT = (N: number, splitIndex: number) =>
   `${SPLIT_N(splitIndex)} ${_PROMPT_BLOCK_N(N)}`
 export const PROMPT_N_FOR_SPLIT = (N: number, splitIndex: number) =>
   `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} ${_PROMPT}`
-export const PROMPT_BLOCK_LAST_FOR_SPLIT = (splitIndex = 1) => `${PROMPT_BLOCK_FOR_SPLIT(splitIndex)}:nth-last-child(2)`
+
+// in notebooks, there is no active block, hence the nth-last-child(1)
+export const PROMPT_BLOCK_LAST = `${PROMPT_BLOCK}:nth-last-child(2)`
+export const PROMPT_BLOCK_LAST_IN_NOTEBOOK = (N = 1) => `${PROMPT_BLOCK}:nth-last-child(${N})`
+export const PROMPT_BLOCK_LAST_FOR_SPLIT_IN_NOTEBOOK = (splitIndex = 1, N = 1) =>
+  `${PROMPT_BLOCK_FOR_SPLIT(splitIndex)}:nth-last-child(${N})`
+export const PROMPT_BLOCK_LAST_FOR_SPLIT = (splitIndex = 1, N = 1, inNotebook = false) => {
+  if (!inNotebook) {
+    return `${PROMPT_BLOCK_FOR_SPLIT(splitIndex)}:nth-last-child(${N + 1})`
+  } else {
+    return PROMPT_BLOCK_LAST_FOR_SPLIT_IN_NOTEBOOK(splitIndex, N)
+  }
+}
+export const PROMPT_LAST = `${PROMPT_BLOCK_LAST} .repl-input-element`
+export const PROMPT_LAST_IN_NOTEBOOK = (N = 1) => `${PROMPT_BLOCK_LAST_IN_NOTEBOOK(N)} .repl-input-element`
 export const OUTPUT_LAST_FOR_SPLIT = (splitIndex: number) => `${PROMPT_BLOCK_LAST_FOR_SPLIT(splitIndex)} .repl-result`
+export const OUTPUT_LAST_FOR_SPLIT_IN_NOTEBOOK = (splitIndex: number, N = 1) =>
+  `${PROMPT_BLOCK_LAST_FOR_SPLIT_IN_NOTEBOOK(splitIndex, N)} .repl-result`
+export const OUTPUT_LAST = `${PROMPT_BLOCK_LAST} .repl-result`
+export const OUTPUT_LAST_IN_NOTEBOOK = (N = 1) => `${PROMPT_BLOCK_LAST_IN_NOTEBOOK(N)} .repl-result`
+export const OUTPUT_LAST_STREAMING = `${PROMPT_BLOCK_LAST} [data-stream]`
+export const OUTPUT_LAST_STREAMING_IN_NOTEBOOK = `${PROMPT_BLOCK_LAST_IN_NOTEBOOK} [data-stream]`
+
+export const OUTPUT_LAST_PTY = OUTPUT_LAST
+export const OUTPUT_LAST_PTY_IN_NOTEBOOK = OUTPUT_LAST_IN_NOTEBOOK
 
 /**
  * Terminal card
@@ -189,7 +212,6 @@ export const OUTPUT_N = (N: number, splitIndex = 1) => `${PROMPT_BLOCK_N_FOR_SPL
 export const OUTPUT_N_STREAMING = (N: number, splitIndex = 1) =>
   `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} [data-stream]`
 export const OUTPUT_N_PTY = (N: number) => OUTPUT_N(N)
-export const PROMPT_BLOCK_LAST = `${PROMPT_BLOCK}:nth-last-child(2)`
 export const EXPERIMENTAL_PROMPT_BLOCK_TAG = `${PROMPT_BLOCK_LAST} .kui--repl-block-experimental-tag`
 export const PROMPT_BLOCK_FINAL = `${PROMPT_BLOCK}:nth-last-child(1)`
 export const OVERFLOW_MENU = '.kui--repl-block-right-element.kui--toolbar-button-with-icon'
@@ -203,11 +225,7 @@ export const COMMAND_COPY_BUTTON = (N: number) => `${PROMPT_BLOCK_N(N)} .kui--bl
 export const COMMAND_COPY_DONE_BUTTON = (N: number) => `${PROMPT_BLOCK_N(N)} .kui--block-action [icon="Checkmark"]`
 export const COMMAND_RERUN_BUTTON = (N: number, splitIndex = 1) =>
   `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} .kui--block-action [icon="Play"]`
-export const PROMPT_LAST = `${PROMPT_BLOCK_LAST} .repl-input-element`
 export const PROMPT_FINAL = `${PROMPT_BLOCK_FINAL} .repl-input-element`
-export const OUTPUT_LAST = `${PROMPT_BLOCK_LAST} .repl-result`
-export const OUTPUT_LAST_STREAMING = `${PROMPT_BLOCK_LAST} [data-stream]`
-export const OUTPUT_LAST_PTY = OUTPUT_LAST
 export const LIST_RESULTS_N = (N: number, splitIndex = 1) =>
   `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} .repl-result tbody tr`
 
@@ -366,8 +384,12 @@ export const EXPANDABLE_OUTPUT_N = (N: number, splitIndex = 1) =>
   `${PROMPT_BLOCK_N_FOR_SPLIT(N, splitIndex)} .kui--expandable-section button`
 export const EXPANDABLE_OUTPUT_LAST = (splitIndex = 1) =>
   `${PROMPT_BLOCK_LAST_FOR_SPLIT(splitIndex)} .kui--expandable-section button`
+export const EXPANDABLE_OUTPUT_LAST_IN_NOTEBOOK = (splitIndex = 1, N = 1) =>
+  `${PROMPT_BLOCK_LAST_FOR_SPLIT_IN_NOTEBOOK(splitIndex, N)} .kui--expandable-section button`
 
 /** DescriptionList */
 export const DLIST = '.kui--description-list'
 export const DLIST_DESCRIPTION_FOR = (term: string) =>
   `.kui--description-list-term[data-term=${term}] + .kui--description-list-description`
+
+export const tabButtonSelector = '#new-tab-button'

--- a/plugins/plugin-bash-like/src/test/bash-like/replay.ts
+++ b/plugins/plugin-bash-like/src/test/bash-like/replay.ts
@@ -48,7 +48,7 @@ describe(`bash-like snapshot and replay ${process.env.MOCHA_RUN_TARGET || ''}`, 
       let idx = 0
       await this.app.client.waitUntil(
         async () => {
-          const txt = await this.app.client.$(Selectors.OUTPUT_LAST_PTY).then(_ => _.getText())
+          const txt = await this.app.client.$(Selectors.OUTPUT_LAST_PTY_IN_NOTEBOOK()).then(_ => _.getText())
           if (++idx > 5) {
             console.error(`still waiting for expected=${curentDirectory}; actual=${txt}`)
           }

--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -69,6 +69,13 @@ export default class TabContainer extends React.PureComponent<Props, State> {
     eventBus.on('/tab/switch/request', (idx: number) => {
       this.onSwitchTab(idx)
     })
+
+    eventBus.on('/kui/tab/edit/toggle/index', (idx: number) => {
+      const tab = this.state.tabs[idx]
+      if (tab && tab.uuid) {
+        eventBus.emitWithTabId('/kui/tab/edit/toggle', tab.uuid)
+      }
+    })
   }
 
   /** save tab state such as CWD prior to a tab switch */

--- a/plugins/plugin-client-common/src/components/Client/TabContent.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContent.tsx
@@ -277,6 +277,7 @@ export default class TabContent extends React.PureComponent<Props, State> {
               ref={this.state._terminal}
               hasBottomStrip={this.state.hasBottomStrip}
               willToggleBottomStripMode={this._toggleBottomStripMode}
+              noActiveInput={this.props.noActiveInput || !this.state.mutability.editable}
             >
               {this.children()}
             </ScrollableTerminal>

--- a/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/Block/index.tsx
@@ -154,9 +154,12 @@ export default class Block extends React.PureComponent<Props, State> {
     if (this.props.onOutputRender) {
       this.props.onOutputRender()
     }
-    if (this.props.noActiveInput && this.state._block) {
+
+    // oof: this is for bottom input clients... but it messes up
+    // notebooks, constantly scrolling to bottom...
+    /* if (this.props.noActiveInput && this.state._block) {
       this.state._block.scrollIntoView()
-    }
+    } */
   }
 
   private readonly _onOutputRender = this.onOutputRender.bind(this)

--- a/plugins/plugin-client-common/src/components/Views/Terminal/ScrollbackState.ts
+++ b/plugins/plugin-client-common/src/components/Views/Terminal/ScrollbackState.ts
@@ -74,7 +74,12 @@ type ScrollbackState = ScrollbackOptions & {
   willInsertSection: (idx: number) => void
   willLinkifyBlock: (idx: number) => void
   willUpdateExecutable: () => void
-  tabRefFor: (ref: HTMLElement) => void
+
+  /** Reference for the entire Split */
+  tabRefFor(ref: HTMLElement): void
+
+  /** Reference for the scrollable part of the Split; helpful for scrollToTop/Bottom */
+  scrollableRef(ref: HTMLElement): void
 }
 
 export default ScrollbackState

--- a/plugins/plugin-client-common/src/test/core/notebooks-readonly.ts
+++ b/plugins/plugin-client-common/src/test/core/notebooks-readonly.ts
@@ -14,24 +14,18 @@
  * limitations under the License.
  */
 
-import { Common, CLI, ReplExpect, Selectors } from '@kui-shell/test'
+import { Common, CLI, Selectors, Util } from '@kui-shell/test'
 
 const TIMEOUT = 1000
 
 Common.localDescribe('notebooks read only mode', function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
+  Util.closeAllExceptFirstTab.bind(this)
 
   const openNotebook = () => {
-    it('should open a notebook using a CLI command', async () => {
-      try {
-        await CLI.command('replay /kui/welcome.json', this.app)
-          .then(ReplExpect.error(127))
-          .catch(Common.oops(this, true))
-      } catch (err) {
-        return Common.oops(this, true)(err)
-      }
-    })
+    it('should open a notebook using a CLI command', () =>
+      CLI.command('replay /kui/welcome.json', this.app).catch(Common.oops(this, true)))
   }
 
   const splitHeadersCheck = () => {
@@ -63,7 +57,7 @@ Common.localDescribe('notebooks read only mode', function(this: Common.ISuite) {
         // For notebooks being used for this test, the block at split index 2 will be used
         const splitIndex = 2
 
-        const N = (await CLI.lastBlock(this.app, splitIndex)).count
+        const N = (await CLI.lastBlock(this.app, splitIndex, 1, true)).count
 
         // the replay button should be showing
         await this.app.client

--- a/plugins/plugin-core-support/src/test/core-support/clear.ts
+++ b/plugins/plugin-core-support/src/test/core-support/clear.ts
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-import { Common, CLI, Keys, ReplExpect, Selectors, SidecarExpect } from '@kui-shell/test'
-
-export function doClear(this: Common.ISuite, residualBlockCount = 1, splitIndex = 1) {
-  return CLI.commandInSplit('clear', this.app, splitIndex)
-    .then(() => ReplExpect.consoleToBeClear(this.app, residualBlockCount, splitIndex))
-    .then(() => SidecarExpect.closed)
-    .catch(Common.oops(this, true))
-}
+import { Common, CLI, Keys, ReplExpect, Selectors, Util } from '@kui-shell/test'
 
 describe(`clear the console from scratch ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: Common.ISuite) {
   before(Common.before(this))
   after(Common.after(this))
 
-  const clear = doClear.bind(this)
+  const clear = Util.doClear.bind(this)
 
   it('should clear the console from scratch', () => clear())
   it('should use echo via kuiecho', () =>
@@ -40,7 +33,7 @@ describe(`clear the console ${process.env.MOCHA_RUN_TARGET || ''}`, function(thi
   before(Common.before(this))
   after(Common.after(this))
 
-  const clear = doClear.bind(this)
+  const clear = Util.doClear.bind(this)
 
   interface PromptOptions {
     enteredString?: string

--- a/plugins/plugin-kubectl/src/test/k8s3/replay.ts
+++ b/plugins/plugin-kubectl/src/test/k8s3/replay.ts
@@ -54,18 +54,21 @@ describe(`kubectl replay ${process.env.MOCHA_RUN_TARGET || ''}`, function(this: 
       console.error('snapshoting')
       await CLI.command(`snapshot ${file}`, this.app).then(ReplExpect.justOK)
 
-      console.error('replaying')
+      console.error('refreshing')
       await Common.refresh(this)
 
+      console.error('replaying')
       await CLI.command(`replay ${file}`, this.app)
 
       await CLI.expandLast(this.app)
 
-      await waitForRed(this.app, `${Selectors.OUTPUT_LAST} ${Selectors.BY_NAME('nginx')}`)
+      await waitForRed(this.app, `${Selectors.OUTPUT_LAST_IN_NOTEBOOK()} ${Selectors.BY_NAME('nginx')}`)
     } catch (err) {
       await Common.oops(this, true)(err)
     }
   })
+
+  it('should switch to the first tab', () => Util.switchToTopLevelTabViaClick(this, 1))
 
   deleteNS(this, ns, 'kubectl')
 })
@@ -95,7 +98,7 @@ describe(`kubectl replay with re-execution ${process.env.MOCHA_RUN_TARGET || ''}
       await this.app.client.waitUntil(
         async () => {
           const errorMessage = await this.app.client
-            .$(`${Selectors.OUTPUT_LAST}.oops[data-status-code="409"]`)
+            .$(`${Selectors.OUTPUT_LAST_IN_NOTEBOOK()}.oops[data-status-code="409"]`)
             .then(_ => _.getText())
           return errorMessage.includes('pods "nginx"')
         },
@@ -106,6 +109,7 @@ describe(`kubectl replay with re-execution ${process.env.MOCHA_RUN_TARGET || ''}
     }
   })
 
+  it('should switch to the first tab', () => Util.switchToTopLevelTabViaClick(this, 1))
   deleteNS(this, ns, 'kubectl')
 })
 
@@ -133,20 +137,24 @@ describe(`kubectl replay with clicks ${process.env.MOCHA_RUN_TARGET || ''}`, asy
 
       await CLI.expandLast(this.app)
 
-      await this.app.client.$(`${Selectors.OUTPUT_LAST} ${Selectors.BY_NAME('nginx')}`).then(_ => _.waitForDisplayed())
+      await this.app.client
+        .$(`${Selectors.OUTPUT_LAST_IN_NOTEBOOK()} ${Selectors.BY_NAME('nginx')}`)
+        .then(_ => _.waitForDisplayed())
       await Util.openSidecarByClick(
         this,
-        `${Selectors.OUTPUT_LAST} ${Selectors.BY_NAME('nginx')} .clickable`,
+        `${Selectors.OUTPUT_LAST_IN_NOTEBOOK()} ${Selectors.BY_NAME('nginx')} .clickable`,
         'nginx',
         defaultModeForGet,
         undefined,
-        1 // replayed clicks currently don't support opening in a split; see https://github.com/IBM/kui/issues/6785
+        1, // replayed clicks currently don't support opening in a split; see https://github.com/IBM/kui/issues/6785
+        true // we are in a notebook
       )
     } catch (err) {
       await Common.oops(this, true)(err)
     }
   })
 
+  it('should switch to the first tab', () => Util.switchToTopLevelTabViaClick(this, 1))
   deleteNS(this, ns, 'kubectl')
 })
 
@@ -177,11 +185,14 @@ describe(`kubectl replay with grid table ${process.env.MOCHA_RUN_TARGET || ''}`,
 
       await CLI.expandLast(this.app)
 
-      await this.app.client.$(`${Selectors.OUTPUT_LAST} ${Selectors._TABLE_AS_GRID}`).then(_ => _.waitForDisplayed())
+      await this.app.client
+        .$(`${Selectors.OUTPUT_LAST_IN_NOTEBOOK()} ${Selectors._TABLE_AS_GRID}`)
+        .then(_ => _.waitForDisplayed())
     } catch (err) {
       await Common.oops(this, true)(err)
     }
   })
 
+  it('should switch to the first tab', () => Util.switchToTopLevelTabViaClick(this, 1))
   deleteNS(this, ns, 'kubectl')
 })


### PR DESCRIPTION
Fixes #8152
Fixes #8151

This PR uses a fix for #8151 to clean up the solution to #8152: as long as we aren't trying to focus the active block, we can simplify keeping the notebooks scrolled to top.

This PR also fixes a regression in the `split.scrollToTop` impl.

This PR also fixes many bugs in the toggle editability code and tests. e.g. the `tab edit toggle` command handler was not properly dealing with tab indices.

Some test updates were needed to cope with the new lack of an active prompt in notebook tabs.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
