### PR TITLE
fix(plugins/plugin-core-support): ReadOnly clients cannot toggle edit…

### DIFF
--- a/plugins/plugin-core-support/src/lib/cmds/toggle-editability.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/toggle-editability.ts
@@ -18,6 +18,7 @@ import {
   eventBus,
   getPrimaryTabId,
   getTab,
+  isReadOnlyClient,
   KResponse,
   ParsedOptions,
   Registrar,
@@ -58,23 +59,25 @@ function getTabByIndex(argvNoOptions: string[]): Tab {
 
 /** Command registration */
 export default function(registrar: Registrar) {
-  // register the `tab edit toggle` command
-  registrar.listen<KResponse, EditOptions>(
-    '/tab/edit/toggle',
-    ({ tab, argvNoOptions, parsedOptions }) => {
-      if (!parsedOptions.c && argvNoOptions.length < 4) {
-        throw new Error('Not enough arguments. Expected: tab edit toggle tabIndexNum')
-      }
-      if (argvNoOptions.length > 4) {
-        throw new Error('Too many arguments. Expected: tab edit toggle tabIndexNum')
-      }
+  if (!isReadOnlyClient()) {
+    // register the `tab edit toggle` command
+    registrar.listen<KResponse, EditOptions>(
+      '/tab/edit/toggle',
+      ({ tab, argvNoOptions, parsedOptions }) => {
+        if (!parsedOptions.c && argvNoOptions.length < 4) {
+          throw new Error('Not enough arguments. Expected: tab edit toggle tabIndexNum')
+        }
+        if (argvNoOptions.length > 4) {
+          throw new Error('Too many arguments. Expected: tab edit toggle tabIndexNum')
+        }
 
-      const desiredTab = parsedOptions.c ? tab : getTabByIndex(argvNoOptions)
+        const desiredTab = parsedOptions.c ? tab : getTabByIndex(argvNoOptions)
 
-      const uuid = getPrimaryTabId(desiredTab)
-      eventBus.emitWithTabId('/kui/tab/edit/toggle', uuid, desiredTab)
-      return 'Successfully toggled edit mode'
-    },
-    { usage, flags: { alias: { 'current-tab': ['c'] }, boolean: ['c'] } }
-  )
+        const uuid = getPrimaryTabId(desiredTab)
+        eventBus.emitWithTabId('/kui/tab/edit/toggle', uuid, desiredTab)
+        return 'Successfully toggled edit mode'
+      },
+      { usage, flags: { alias: { 'current-tab': ['c'] }, boolean: ['c'] } }
+    )
+  }
 }


### PR DESCRIPTION
… mode

Fixes #8149 
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Disabled the ability for clients with read only permissions to toggle edit mode

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
