### PR TITLE
fix: Read only and offline only clients cannot toggle edit mode

### DIFF
--- a/packages/core/src/main/menu.ts
+++ b/packages/core/src/main/menu.ts
@@ -23,6 +23,7 @@ import open from './open'
 import saveAsNotebook from './save'
 import tellRendererToExecute from './tell'
 import { openNotebook, loadClientNotebooksMenuDefinition, clientNotebooksDefinitionToElectron } from './notebooks'
+import { isOfflineClient, isReadOnlyClient } from '..'
 
 const isDev = false
 
@@ -86,6 +87,7 @@ export const install = (createWindow: (executeThisArgvPlease?: string[]) => void
       { type: 'separator' },
       {
         label: 'Toggle Edit Mode',
+        enabled: !(isReadOnlyClient() || isOfflineClient()),
         click: () => tellRendererToExecute('tab edit toggle --current-tab')
         // TODO find exactly what keyboard shortcut => accelerator: 'CommandOrControl+E'
       },

--- a/plugins/plugin-core-support/src/lib/cmds/toggle-editability.ts
+++ b/plugins/plugin-core-support/src/lib/cmds/toggle-editability.ts
@@ -17,6 +17,7 @@
 import {
   eventBus,
   getPrimaryTabId,
+  isOfflineClient,
   isReadOnlyClient,
   KResponse,
   ParsedOptions,
@@ -53,7 +54,7 @@ function getTabIndex(argvNoOptions: string[]): number {
 
 /** Command registration */
 export default function(registrar: Registrar) {
-  if (!isReadOnlyClient()) {
+  if (!(isReadOnlyClient() || isOfflineClient())) {
     // register the `tab edit toggle` command
     registrar.listen<KResponse, EditOptions>(
       '/tab/edit/toggle',


### PR DESCRIPTION
Fixes #8149 

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
These changes ensure that read only clients and offline clients cannot toggle edit mode either through the CLI command or through the OS menu.
<img width="1182" alt="disabledToggleEditMenu" src="https://user-images.githubusercontent.com/16118462/137031008-46121c7a-243c-4456-b3b7-bb8fc8d2b9d5.png">

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
