### PR TITLE
feat: allow `replay` command to open multiple notebooks

### DIFF
--- a/packages/core/src/core/events.ts
+++ b/packages/core/src/core/events.ts
@@ -61,26 +61,28 @@ class EventBusBase {
 }
 
 export interface NewTabRequestEvent {
-  /** Optionally specify color and message to display in the StatusStripe */
-  statusStripeDecoration?: StatusStripeChangeEvent
-
-  /** Optional tab title */
-  title?: string
-
   /** Optionally specify to create the new tab without switching to it */
   background?: boolean
 
-  /** Optionally execute a command in the new tab */
-  cmdline?: string
+  tabs: {
+    /** Optionally specify color and message to display in the StatusStripe */
+    statusStripeDecoration?: StatusStripeChangeEvent
 
-  /** Optionally open a snapshot file in the new tab */
-  snapshot?: Buffer
+    /** Optional tab title */
+    title?: string
 
-  /** Execute the command line with qexec or pexec? Default: pexec. */
-  exec?: 'pexec' | 'qexec'
+    /** Optionally execute a command in the new tab */
+    cmdline?: string
 
-  /** Optionally execute a command when the tab is closed */
-  onClose?: string
+    /** Execute the command line with qexec or pexec? Default: pexec. */
+    exec?: 'pexec' | 'qexec'
+
+    /** Optionally open a snapshot file in the new tab */
+    snapshot?: Buffer
+
+    /** Optionally execute a command when the tab is closed */
+    onClose?: string
+  }[]
 }
 
 class WriteEventBus extends EventBusBase {

--- a/plugins/plugin-client-common/src/components/Client/TabModel.ts
+++ b/plugins/plugin-client-common/src/components/Client/TabModel.ts
@@ -36,7 +36,7 @@ export default class TabModel {
     private readonly _buttons: TopTabButton[] = [],
     private readonly _initialCommandLine?: string,
     private readonly _onClose?: string,
-    private readonly _exec?: NewTabRequestEvent['exec'],
+    private readonly _exec?: NewTabRequestEvent['tabs'][0]['exec'],
     /** If field is defined then this is the serialized form of the notebook to be displayed on this tab */
     private readonly _snapshot?: Buffer
   ) {


### PR DESCRIPTION
BREAKING CHANGE: This PR is a breaking change to the new tab event model: it is now an array, rather than a singleton.

Fixes #8162

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
