### PR TITLE
fix: can't switch to tab whose CWD has been removed

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -286,7 +286,7 @@ export {
 
 // Util
 export { findFileWithViewer, findFile, isSpecialDirectory } from './core/find-file'
-export { expandHomeDir, cwd } from './util/home'
+export { expandHomeDir, cwd, fallbackCWD } from './util/home'
 export { flatten } from './core/utility'
 export { promiseEach } from './util/async'
 export { isHTML, isPromise } from './util/types'

--- a/packages/core/src/util/home.ts
+++ b/packages/core/src/util/home.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { homedir as home } from 'os'
 
 import { inBrowser } from '../core/capabilities'
@@ -37,6 +37,15 @@ export const expandHomeDir = function(path: string): string {
 
 export default expandHomeDir
 
+/** In case of error, e.g. removed CWD, this is our fallback plan */
+export function fallbackCWD(cwd?: string) {
+  if (cwd) {
+    return dirname(cwd)
+  } else {
+    return process.env.HOME || _homedir || '/'
+  }
+}
+
 export const cwd = () => {
   try {
     return (
@@ -45,9 +54,9 @@ export const cwd = () => {
   } catch (err) {
     // it could be that the underlying directory disappeared
     // see https://github.com/kubernetes-sigs/kui/issues/8160
-    console.error(err)
+    console.error('Using fallback plan due to error', err)
 
     // fallback plan:
-    return process.env.PWD || process.env.HOME || _homedir || '/'
+    return fallbackCWD()
   }
 }


### PR DESCRIPTION
Fixes #8173

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
