### PR TITLE
fix: webpack build script does not allow overriding of bundle output …

### DIFF
--- a/packages/webpack/build.sh
+++ b/packages/webpack/build.sh
@@ -42,7 +42,7 @@ echo "staging directory: $STAGING"
 CLIENT_HOME="$(pwd)"
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 BUILDER_HOME="$CLIENT_HOME"/node_modules/@kui-shell/builder
-BUILDDIR="$CLIENT_HOME"/dist/webpack
+BUILDDIR=${BUILDDIR-"$CLIENT_HOME"/dist/webpack}
 
 APPDIR="$STAGING"/node_modules/@kui-shell
 CORE_HOME="$STAGING"/node_modules/@kui-shell/core


### PR DESCRIPTION
…directory

packages/webpack/build.sh hard-codes this to dist/webpack

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
