### PR TITLE
fix(plugins/plugin-core-support): `up` command uses alphabetical orde…

### DIFF
--- a/plugins/plugin-core-support/up/src/Group.ts
+++ b/plugins/plugin-core-support/up/src/Group.ts
@@ -19,7 +19,17 @@ enum Group {
   Compute,
   Authorization,
   CLI,
+  CLIPlugin,
   Operator
+}
+
+export const GroupPriority = {
+  CLI: 0,
+  CLIPlugin: 1,
+  Authorization: 2,
+  Operator: 3,
+  Compute: 4,
+  Storage: 4
 }
 
 export default Group

--- a/plugins/plugin-core-support/up/src/ui.ts
+++ b/plugins/plugin-core-support/up/src/ui.ts
@@ -19,9 +19,9 @@ import colors from 'colors/safe'
 import { Observable, Observer } from 'rxjs'
 import { Arguments, Streamable } from '@kui-shell/core'
 
-import Group from './Group'
 import Options from './options'
 import checkers from './registrar'
+import Group, { GroupPriority } from './Group'
 import Checker, { CheckerArgs, CheckResult, Stdout } from './Checker'
 
 /** indicator of failure */
@@ -144,7 +144,7 @@ export async function checkPrerequistes(
   // top-level grouping
   const groups = Object.values(Group)
     .filter(_ => isNaN(Number(_)))
-    .sort()
+    .sort((a, b) => GroupPriority[a] - GroupPriority[b])
   const nGroups = groups.length
 
   const tasks = new Listr<Pick<Status, 'ok'>[]>(


### PR DESCRIPTION
…ring

This may be fine when checking prereqs, but does not work when fixing prereqs! For example, the CLI needs to be installed before it can be used to fix an authorization gap.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
