### PR TITLE
fix(plugins/plugin-core-support): `up` output does not clarify which …

### DIFF
--- a/plugins/plugin-core-support/up/src/kubernetes/kubectl.ts
+++ b/plugins/plugin-core-support/up/src/kubernetes/kubectl.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// import colors from 'colors/safe'
+import colors from 'colors/safe'
 import { Arguments } from '@kui-shell/core'
 import { doExecWithStdoutViaPty } from '@kui-shell/plugin-bash-like'
 
@@ -35,9 +35,8 @@ async function check(args: Arguments) {
 export default {
   service,
   group: Group.CLI,
-  label: 'kubectl',
-  // (checkResult?: false | string) =>
-  //    checkResult === undefined ? 'Installed' : !checkResult ? 'not installed' : colors.gray(checkResult),
+  label: (checkResult?: false | string) =>
+    checkResult === undefined ? 'kubectl' : !checkResult ? 'not installed' : colors.gray(checkResult),
   description: 'The kubectl CLI allows access to your Kubernetes clusters',
   check,
   fix:

--- a/plugins/plugin-core-support/up/src/kubernetes/valid-kubeconfig.ts
+++ b/plugins/plugin-core-support/up/src/kubernetes/valid-kubeconfig.ts
@@ -32,8 +32,8 @@ async function check({ REPL }: Pick<Arguments, 'REPL'>) {
 export default {
   service,
   group: Group.Authorization,
-  label: (checkResult?: false | string) =>
-    checkResult === undefined
+  label: (checkResult?: boolean | string) =>
+    checkResult === undefined || checkResult === true
       ? 'Connected to cluster'
       : !checkResult
       ? 'no valid config found'


### PR DESCRIPTION
…service is being presented

This is regarding the ASCII output.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
