### PR TITLE
fix(plugins/plugin-core-support): `up --fix` executes Authorization s…

### DIFF
--- a/plugins/plugin-core-support/up/src/Group.ts
+++ b/plugins/plugin-core-support/up/src/Group.ts
@@ -17,7 +17,10 @@
 enum Group {
   Storage,
   Compute,
-  Authorization,
+  CloudAuthorization,
+  CloudTarget,
+  ClusterAuthorization,
+  ServiceAuthorization,
   CLI,
   CLIPlugin,
   Operator
@@ -26,10 +29,13 @@ enum Group {
 export const GroupPriority = {
   CLI: 0,
   CLIPlugin: 1,
-  Authorization: 2,
-  Operator: 3,
-  Compute: 4,
-  Storage: 4
+  CloudAuthorization: 2,
+  CloudTarget: 3,
+  ClusterAuthorization: 4,
+  ServiceAuthorization: 5,
+  Operator: 6,
+  Compute: 7,
+  Storage: 7
 }
 
 export default Group

--- a/plugins/plugin-core-support/up/src/aws/s3.ts
+++ b/plugins/plugin-core-support/up/src/aws/s3.ts
@@ -25,7 +25,7 @@ async function check({ REPL }: Pick<Arguments, 'REPL'>) {
 }
 
 export default {
-  group: Group.Storage,
+  group: Group.ServiceAuthorization,
   service,
 
   label: 'Valid credentials',

--- a/plugins/plugin-core-support/up/src/ibm/base/login.ts
+++ b/plugins/plugin-core-support/up/src/ibm/base/login.ts
@@ -28,7 +28,7 @@ async function check(args: Arguments) {
 
 export default {
   service,
-  group: Group.Authorization,
+  group: Group.CloudAuthorization,
 
   label: 'IBM Cloud Login',
   description: 'You will need a valid token to access the IBM Cloud',

--- a/plugins/plugin-core-support/up/src/ibm/base/target.ts
+++ b/plugins/plugin-core-support/up/src/ibm/base/target.ts
@@ -44,7 +44,7 @@ async function check(args: Arguments) {
 
 export default {
   service,
-  group: Group.Authorization,
+  group: Group.CloudTarget,
 
   label: (checkResult?: false | string) =>
     checkResult === undefined ? 'IBM Cloud Target' : checkResult === false ? colors.red('not selected') : checkResult,

--- a/plugins/plugin-core-support/up/src/ibm/ce/creds.ts
+++ b/plugins/plugin-core-support/up/src/ibm/ce/creds.ts
@@ -47,7 +47,7 @@ async function fix(args: Arguments<Options>) {
 }
 
 export default {
-  group: Group.Authorization,
+  group: Group.ServiceAuthorization,
   service,
 
   label: (checkResult?: false | string) =>

--- a/plugins/plugin-core-support/up/src/ibm/cos/creds.ts
+++ b/plugins/plugin-core-support/up/src/ibm/cos/creds.ts
@@ -36,7 +36,7 @@ function check({ REPL, parsedOptions }: CheckerArgs<Options>) {
 
 export default {
   service,
-  group: Group.Storage,
+  group: Group.ServiceAuthorization,
 
   label: (checkResult?: false | string) =>
     checkResult === undefined

--- a/plugins/plugin-core-support/up/src/kubernetes/valid-kubeconfig.ts
+++ b/plugins/plugin-core-support/up/src/kubernetes/valid-kubeconfig.ts
@@ -31,7 +31,7 @@ async function check({ REPL }: Pick<Arguments, 'REPL'>) {
 
 export default {
   service,
-  group: Group.Authorization,
+  group: Group.ClusterAuthorization,
   label: (checkResult?: boolean | string) =>
     checkResult === undefined || checkResult === true
       ? 'Connected to cluster'


### PR DESCRIPTION
…teps in poor order

This PR adds a finer grained distinction between different layers of authorization.
- CloudAuthorization
- CloudTarget
- ClusterAuthorization
- ServiceAuthorization

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
