### PR TITLE
fix(plugins/plugin-client-common): Ansi UI does not handle underlined text

### DIFF
--- a/plugins/plugin-client-common/src/components/Content/Scalar/Ansi.tsx
+++ b/plugins/plugin-client-common/src/components/Content/Scalar/Ansi.tsx
@@ -25,10 +25,9 @@ interface Props {
   onRender?: () => void
 }
 
+/** Special overrides for CSS classes; otherwise, we will use the raw values from `anser`, e.g. "italic" and "underline" and "strikethrough" */
 const decos = {
-  dim: 'sub-text semi-transparent',
-  strikethrough: 'strikethrough',
-  italic: 'italic'
+  dim: 'sub-text semi-transparent'
 }
 
 function tagOf(entry: AnserJsonEntry) {
@@ -38,7 +37,7 @@ function tagOf(entry: AnserJsonEntry) {
 function classOf(entry: AnserJsonEntry) {
   const fg = entry.fg ? entry.fg.replace(/^ansi-(.*)/, 'ansi-$1-fg') : ''
   const bg = entry.bg ? entry.bg.replace(/^ansi-(.*)/, 'ansi-$1-bg') : ''
-  const deco = entry.decorations.map(_ => decos[_] || '')
+  const deco = entry.decorations.map(_ => decos[_] || _)
 
   return `${fg} ${bg} ${deco.join(' ')}`
 }
@@ -67,7 +66,7 @@ export default function Ansi(props: Props) {
   }
 
   return (
-    <pre className={props.className} style={{ margin: 0 }}>
+    <pre className={props.className} style={{ margin: 0, wordBreak: 'break-all' }}>
       {model.map(
         (_, idx) => _.content && React.createElement(tagOf(_), { key: idx, className: classOf(_) }, content(_.content))
       )}


### PR DESCRIPTION
We aren't properly handling the `underline` decoration from `anser`.

This PR also adds a `word-break: break-all` to more closely mimic the way `xterm` and terminals generally behave.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
