### PR TITLE
fix: font size for kube context/namespace selectors is too large

### DIFF
--- a/plugins/plugin-client-common/web/scss/components/Select/PatternFly.scss
+++ b/plugins/plugin-client-common/web/scss/components/Select/PatternFly.scss
@@ -51,6 +51,7 @@
   }
 
   button {
+    font-size: inherit;
     padding-top: 0.375em;
     padding-bottom: 0.375em;
   }

--- a/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
+++ b/plugins/plugin-kubectl/components/src/CurrentNamespace.tsx
@@ -243,7 +243,7 @@ export default class CurrentNamespace extends React.PureComponent<Props, State> 
       internalNs.length === 0
         ? undefined
         : [
-            { label: '', options: regularNs },
+            { label: strings('User Namespaces'), options: regularNs },
             { divider: true as const },
             { label: strings('System Namespaces'), options: internalNs }
           ]

--- a/plugins/plugin-kubectl/i18n/resources_en_US.json
+++ b/plugins/plugin-kubectl/i18n/resources_en_US.json
@@ -6,6 +6,7 @@
   "Successfully Applied": "Successfully Applied",
   "This API Resource is deprecated": "This API Resource is deprecated.",
   "Namespace": "Namespace",
+  "User Namespaces": "User Namespaces",
   "System Namespaces": "System Namespaces",
   "This is your current namespace": "This is your current namespace",
   "This is your current context": "This is your current context",


### PR DESCRIPTION
Also adds "User Namespaces" header to CurrentNamespace

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
