### PR TITLE
fix: sigh, npm 8.3.1 (node 16.14.0) broke our colors override

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,6 @@
     "temp-dir": "packages/test/.nyc_output"
   },
   "overrides": {
-    "colors": "1.40.0"
+    "colors": "$colors"
   }
 }


### PR DESCRIPTION
it seems like a bug in npm, as we have a dependence pinned on 1.4.0, and an override specified also to pin 1.4.0 of colors, but `npm ci` with 16.14.0 complains about some non-existent conflict.

the fix seems to be to use `$colors` rather than `1.4.0` in the override declaration

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
