### PR TITLE
fix(packages/test): resolve several test stability issues

### DIFF
--- a/plugins/plugin-client-common/src/test/core/snippets-in-markdown.ts
+++ b/plugins/plugin-client-common/src/test/core/snippets-in-markdown.ts
@@ -48,11 +48,9 @@ const IN1viaUrl: Input = {
 const IN2: Input = {
   input: join(ROOT, 'data', 'snippet2.md'),
   content: `aaa
-${aContent}
-${aContent}
+${aContent} ${aContent}
 bbb
-${bContent}
-${bContent}
+${bContent} ${bContent}
 ccc`
 }
 

--- a/plugins/plugin-core-support/src/test/core-support/theme-widget.ts
+++ b/plugins/plugin-core-support/src/test/core-support/theme-widget.ts
@@ -39,6 +39,8 @@ describe('theme switching via status stripe widget', function(this: Common.ISuit
     }
   })
 
+  it('should sleep a bit for things to settle', () => new Promise(resolve => setTimeout(resolve, 3000)))
+
   it(`should show that we are using the ${altTheme} theme`, () =>
     CLI.command('theme current', this.app)
       .then(ReplExpect.okWithString(altTheme))


### PR DESCRIPTION
1) active prompt issues, e.g.
```
[SUP1] Error: mochaTarget=electron testTitle=editor basics electron
[SUP1] Error: element (".kui--tab-content.visible .kui--scrollback:nth-child(1) .repl-block.repl-active") still not existing after 55000ms
```

2) one of the markdown snippet tests specifies incorrect expected output

3) theme switching test needs hysteresis in one place to account for delay in persistence of the model

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [x] 🐛 Bug fix
- [ ] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
