### PR TITLE
feat: allow clients to disable new tab or new split via <Kui/> props

### DIFF
--- a/plugins/plugin-client-common/src/components/Client/Kui.tsx
+++ b/plugins/plugin-client-common/src/components/Client/Kui.tsx
@@ -339,6 +339,8 @@ export class Kui extends React.PureComponent<Props, State> {
                 version={this.props.version}
                 noActiveInput={this.props.noActiveInput || !!this.props.bottomInput || Client.isOffline()}
                 bottom={bottom}
+                noNewTabButton={this.props.noNewTabButton}
+                noNewSplitButton={this.props.noNewSplitButton}
                 title={this.props.initialTabTitle || (Client.isOffline() ? ' ' : undefined)}
                 onTabReady={this.state.commandLine && this._onTabReady}
                 closeableTabs={this.props.closeableTabs}

--- a/plugins/plugin-client-common/src/components/Client/KuiConfiguration.tsx
+++ b/plugins/plugin-client-common/src/components/Client/KuiConfiguration.tsx
@@ -15,6 +15,7 @@
  */
 
 import InputProps from './props/Input'
+import InterfaceProps from './props/Interface'
 import SessionProps from './props/Session'
 import BrandingProps from './props/Branding'
 import FeatureFlags from './props/FeatureFlags'
@@ -26,6 +27,7 @@ type TestingFlags = {
 
 type KuiConfiguration = Partial<Themes.ThemeProperties> &
   Partial<InputProps> &
+  Partial<InterfaceProps> &
   Partial<SessionProps> &
   Partial<BrandingProps> &
   Partial<FeatureFlags> &

--- a/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TabContainer.tsx
@@ -25,6 +25,7 @@ import TopTabStripe, { TopTabStripeConfiguration } from './TopTabStripe'
 
 import CommonProps from './props/Common'
 import BrandingProps from './props/Branding'
+import InterfaceProps from './props/Interface'
 import GuidebookProps from './props/Guidebooks'
 
 import '../../../web/css/static/TabContainer.scss'
@@ -47,6 +48,7 @@ type TabContainerOptions = TabContentOptions
 type Props = TabContentOptions &
   TopTabStripeConfiguration &
   BrandingProps &
+  InterfaceProps &
   GuidebookProps &
   Pick<CommonProps, 'closeableTabs' | 'noTopTabs'>
 
@@ -298,6 +300,8 @@ export default class TabContainer extends React.PureComponent<Props, State> {
         isSidebarOpen={this.state.isSidebarOpen}
         onToggleSidebar={this.toggleSidebar}
         noTopTabs={this.props.noTopTabs}
+        noNewTabButton={this.props.noNewTabButton}
+        noNewSplitButton={this.props.noNewSplitButton}
         closeableTabs={this.state.tabs.length > 1 && (this.props.closeableTabs || !isReadOnlyClient())}
       />
     )

--- a/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
+++ b/plugins/plugin-client-common/src/components/Client/TopTabStripe/index.tsx
@@ -31,6 +31,7 @@ import TabModel from '../TabModel'
 import KuiContext from '../context'
 import NewTabButton from './NewTabButton'
 import Tab, { TabConfiguration } from './Tab'
+import InterfaceProps from '../props/Interface'
 import SplitTerminalButton from './SplitTerminalButton'
 
 import Icons from '../../spi/Icons'
@@ -62,19 +63,20 @@ import '../../../../web/scss/components/TopTabStripe/_index.scss'
 
 export type TopTabStripeConfiguration = TabConfiguration
 
-type Props = TopTabStripeConfiguration & {
-  tabs: TabModel[]
-  activeIdx: number
-  noTopTabs: boolean
-  closeableTabs: boolean
-  onNewTab: () => void
-  onCloseTab: (idx: number) => void
-  onSwitchTab: (idx: number) => void
+type Props = TopTabStripeConfiguration &
+  InterfaceProps & {
+    tabs: TabModel[]
+    activeIdx: number
+    noTopTabs: boolean
+    closeableTabs: boolean
+    onNewTab: () => void
+    onCloseTab: (idx: number) => void
+    onSwitchTab: (idx: number) => void
 
-  needsSidebar: boolean
-  isSidebarOpen: boolean
-  onToggleSidebar: () => void
-}
+    needsSidebar: boolean
+    isSidebarOpen: boolean
+    onToggleSidebar: () => void
+  }
 
 export default class TopTabStripe extends React.PureComponent<Props> {
   public componentDidMount() {
@@ -149,10 +151,10 @@ export default class TopTabStripe extends React.PureComponent<Props> {
               ))}
             </NavList>
           </Nav>
-          {!isReadOnlyClient() && (
+          {!isReadOnlyClient() && !(this.props.noNewTabButton && this.props.noNewSplitButton) && (
             <div className="kui--top-tab-buttons">
-              <NewTabButton onNewTab={this.props.onNewTab} />
-              <SplitTerminalButton />
+              {!this.props.noNewTabButton && <NewTabButton onNewTab={this.props.onNewTab} />}
+              {!this.props.noNewSplitButton && <SplitTerminalButton />}
             </div>
           )}
         </React.Fragment>

--- a/plugins/plugin-client-common/src/components/Client/props/Interface.ts
+++ b/plugins/plugin-client-common/src/components/Client/props/Interface.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type InterfaceProps = {
+  /** [Optional] Do not show the New Tab button. Default: false */
+  noNewTabButton?: boolean
+
+  /** [Optional] Do not show the New Split button. Default: false */
+  noNewSplitButton?: boolean
+}
+
+export default InterfaceProps

--- a/plugins/plugin-client-common/web/scss/components/TopTabStripe/_mixins.scss
+++ b/plugins/plugin-client-common/web/scss/components/TopTabStripe/_mixins.scss
@@ -30,6 +30,12 @@ $height: 3em;
   }
 }
 
+@mixin TopTabButtons {
+  .kui--top-tab-buttons {
+    @content;
+  }
+}
+
 @mixin TopTabStripeTabOverflowButton {
   .pf-c-nav__scroll-button {
     @content;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Please confirm that your PR fulfills these requirements

- [x] Multiple commits are squashed into one commit.
- [x] The commit message follows [Conventional Commits](https://github.com/IBM/kui/blob/master/CONTRIBUTING.md#conventional-commits), which allows us to autogenerate release notes; e.g. `fix(plugins/plugin-k8s): fixed annoying bugs`
- [x] All npm dependencies are pinned.
